### PR TITLE
update repositories

### DIFF
--- a/mail.ru-cloud.repo
+++ b/mail.ru-cloud.repo
@@ -1,7 +1,0 @@
-[mail.ru-cloud]
-name=mail.ru-cloud repo
-baseurl=https://linuxdesktopcloud.mail.ru/rpm/Fedora/default
-gpgcheck=1
-gpgkey=https://linuxdesktopcloud.mail.ru/mail.ru-cloud.gpg
-enabled=1
-skip_if_unavailable=True

--- a/slack.repo
+++ b/slack.repo
@@ -1,7 +1,7 @@
 [slack]
 name=slack
-baseurl=https://packagecloud.io/slacktechnologies/slack/fedora/25/x86_64
-enabled=0
+baseurl=https://packagecloud.io/slacktechnologies/slack/fedora/21/x86_64
+enabled=1
 gpgcheck=0
 gpgkey=https://packagecloud.io/gpg.key
 sslverify=1

--- a/vk.repo
+++ b/vk.repo
@@ -2,6 +2,6 @@
 name=VK Messenger repository
 baseurl=https://desktop.userapi.com/rpm/master
 gpgcheck=1
-enabled=0
+enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-vk
 skip_if_unavailable=True


### PR DESCRIPTION
Remove mail.ru cloud - no longer available
Change slack baseurl
enable repositories by default